### PR TITLE
Fix conditions for publishing the container

### DIFF
--- a/.github/workflows/build_containers.yml
+++ b/.github/workflows/build_containers.yml
@@ -59,7 +59,7 @@ jobs:
             FROM=${{ matrix.distribution.base }}
 
       - name: Log in to the Container registry
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
         uses: redhat-actions/podman-login@v1
         with:
           registry: ${{ env.REGISTRY }}
@@ -67,7 +67,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Push to GitHub Container Repository
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' }}
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ env.IMAGE_NAME }}


### PR DESCRIPTION
The workflow isn't run on pushes for main, thus the previous condition didn't make much sense. Instead, we want to push the containers on schedule or when the workflow is run manually.